### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="left">
     <a href="https://github.com/snoopy1866/snoopy1866">
-        <img align="center" src="https://github-readme-stats.vercel.app/api?username=snoopy1866&show_icons=true&theme=transparent&include_all_commits">
+        <img align="center" src="https://github-readme-stats.vercel.app/api?username=snoopy1866&show_icons=true&theme=transparent&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage&number_format=long&count_private=true&include_all_commits=true">
     </a>
     <br>
     <br>


### PR DESCRIPTION
把数据统计卡片补充为完整的数据了，此外，将统计全部数据（不只是最近一年）的选项设为 `true` 了，然后等级就变成 **S** 了

这个等级的具体的计算规则见：https://github.com/anuraghazra/github-readme-stats/blob/master/src/calculateRank.js

这里放上预览效果：

![preview](https://github-readme-stats.vercel.app/api?username=snoopy1866&show_icons=true&theme=transparent&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage&number_format=long&count_private=true&include_all_commits=true)

可以根据需求，删除不想显示的数据 :)